### PR TITLE
Support for login via OpenId

### DIFF
--- a/src/FaluCli/Client/HttpAuthenticationHandler.cs
+++ b/src/FaluCli/Client/HttpAuthenticationHandler.cs
@@ -17,9 +17,7 @@ internal class HttpAuthenticationHandler : DelegatingHandler
                                      IDiscoveryCache discoveryCache,
                                      InvocationContext context,
                                      IConfigValuesProvider configValuesProvider,
-                                     HttpMessageHandler innerHandler,
                                      ILoggerFactory loggerFactory)
-        : base(innerHandler)
     {
         this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         this.discoveryCache = discoveryCache ?? throw new ArgumentNullException(nameof(discoveryCache));

--- a/src/FaluCli/Client/HttpAuthenticationHandler.cs
+++ b/src/FaluCli/Client/HttpAuthenticationHandler.cs
@@ -36,7 +36,7 @@ internal class HttpAuthenticationHandler : DelegatingHandler
             // if we do not have a key, we need to have it pulled from the configuration
             if (string.IsNullOrWhiteSpace(key))
             {
-                var config = configValuesProvider.GetConfigValues();
+                var config = await configValuesProvider.GetConfigValuesAsync(cancellationToken);
 
                 // ensure we have login information
                 if (config.Authentication is null)

--- a/src/FaluCli/Client/HttpAuthenticationHandler.cs
+++ b/src/FaluCli/Client/HttpAuthenticationHandler.cs
@@ -1,0 +1,86 @@
+﻿using Falu.Config;
+using IdentityModel.Client;
+using System.Net.Http.Headers;
+
+namespace Falu.Client;
+
+internal class HttpAuthenticationHandler : DelegatingHandler
+{
+    private const string AuthMissingMessage = "Authentication information is missing. Either pass an api key via --apikey option or perform login via the login command.";
+    private readonly IHttpClientFactory httpClientFactory;
+    private readonly IDiscoveryCache discoveryCache;
+    private readonly InvocationContext context;
+    private readonly IConfigValuesProvider configValuesProvider;
+    private readonly ILogger logger;
+
+    public HttpAuthenticationHandler(IHttpClientFactory httpClientFactory,
+                                     IDiscoveryCache discoveryCache,
+                                     InvocationContext context,
+                                     IConfigValuesProvider configValuesProvider,
+                                     HttpMessageHandler innerHandler,
+                                     ILoggerFactory loggerFactory)
+        : base(innerHandler)
+    {
+        this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        this.discoveryCache = discoveryCache ?? throw new ArgumentNullException(nameof(discoveryCache));
+        this.context = context ?? throw new ArgumentNullException(nameof(context));
+        this.configValuesProvider = configValuesProvider ?? throw new ArgumentNullException(nameof(configValuesProvider));
+        logger = loggerFactory?.CreateOpenIdLogger() ?? throw new ArgumentNullException(nameof(loggerFactory));
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var header = request.Headers.Authorization;
+        if (header is null || header.Parameter == Constants.DefaultApiKey)
+        {
+            var key = context.ParseResult.ValueForOption<string>("--apikey");
+
+            // if we do not have a key, we need to have it pulled from the configuration
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                var config = configValuesProvider.GetConfigValues();
+
+                // ensure we have login information
+                if (config.Authentication is null)
+                {
+                    throw new FaluException(AuthMissingMessage);
+                }
+
+                // ensure we have a valid access token or refresh token
+                if (!config.Authentication.HasValidAccessToken() && !config.Authentication.HasValidRefreshToken())
+                {
+                    throw new FaluException(AuthMissingMessage);
+                }
+
+                // at this point, we either have a valid access token or an invalid acess token with a valid refresh token
+                // if the access token is invalid, we need to get one via the refresh token
+                if (!config.Authentication.HasValidAccessToken())
+                {
+                    logger.LogInformation("Requesting for a new access token using the saved refresh token");
+                    // perform confirguration discovery
+                    var disco = await discoveryCache.GetSafelyAsync(cancellationToken);
+
+                    // request for a new token using the refresh token
+                    var rtr = new RefreshTokenRequest
+                    {
+                        Address = disco.TokenEndpoint,
+                        ClientId = Constants.ClientId,
+                        RefreshToken = config.Authentication.RefreshToken,
+                    };
+                    var client = httpClientFactory.CreateOpenIdClient();
+                    var token_resp = await client.RequestRefreshTokenAsync(rtr, cancellationToken);
+                    logger.LogInformation("Access token refreshed.");
+                    await configValuesProvider.SaveConfigValuesAsync(token_resp, cancellationToken);
+                }
+
+                key = config.Authentication.AccessToken;
+            }
+
+            // at this point we have a key and we can proceed to set the authentication header
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        }
+
+        // perform the request
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/FaluCli/Commands/Login/LoginCommand.cs
+++ b/src/FaluCli/Commands/Login/LoginCommand.cs
@@ -4,9 +4,8 @@ internal class LoginCommand : Command
 {
     public LoginCommand() : base("login", "Login to your Falu account to setup the CLI")
     {
-        this.AddOption(new[] { "-i", "--interactive", },
-                       description: "Run interactive configuration mode if you cannot open a browser.",
-                       defaultValue: false);
-
+        //this.AddOption(new[] { "-i", "--interactive", },
+        //               description: "Run interactive configuration mode if you cannot open a browser.",
+        //               defaultValue: false);
     }
 }

--- a/src/FaluCli/Commands/Login/LoginCommand.cs
+++ b/src/FaluCli/Commands/Login/LoginCommand.cs
@@ -1,0 +1,12 @@
+﻿namespace Falu.Commands.Login;
+
+internal class LoginCommand : Command
+{
+    public LoginCommand() : base("login", "Login to your Falu account to setup the CLI")
+    {
+        this.AddOption(new[] { "-i", "--interactive", },
+                       description: "Run interactive configuration mode if you cannot open a browser.",
+                       defaultValue: false);
+
+    }
+}

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -6,11 +6,6 @@ namespace Falu.Commands.Login;
 
 internal class LoginCommandHandler : ICommandHandler
 {
-    private static readonly string Scopes = string.Join(" ",
-                                                        OidcConstants.StandardScopes.Profile,
-                                                        OidcConstants.StandardScopes.OfflineAccess,
-                                                        Constants.ScopeApi);
-
     private readonly HttpClient client;
     private readonly IDiscoveryCache discoveryCache;
     private readonly ILogger logger;
@@ -51,7 +46,7 @@ internal class LoginCommandHandler : ICommandHandler
             Address = disco.DeviceAuthorizationEndpoint,
             ClientId = Constants.ClientId,
             ClientCredentialStyle = ClientCredentialStyle.PostBody,
-            Scope = Scopes,
+            Scope = Constants.Scopes,
         };
         var response = await client.RequestDeviceAuthorizationAsync(request, cancellationToken);
         if (response.IsError) throw new LoginException(response.Error);

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -56,6 +56,8 @@ internal class LoginCommandHandler : ICommandHandler
         logger.LogInformation("Device code : {DeviceCode}", response.DeviceCode);
         logger.LogInformation("Opening your browser at {VerificationUri}", response.VerificationUri);
 
+        // delay for 2 seconds before opening the browser for the user to see the code
+        await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
         Process.Start(new ProcessStartInfo(response.VerificationUriComplete) { UseShellExecute = true });
 
         return response;

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -66,6 +66,8 @@ internal class LoginCommandHandler : ICommandHandler
     {
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var request = new DeviceTokenRequest
             {
                 Address = disco.TokenEndpoint,

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -45,7 +45,7 @@ internal class LoginCommandHandler : ICommandHandler
             RefreshToken = token_resp.RefreshToken,
             AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(token_resp.ExpiresIn).AddSeconds(-5),
         };
-        await configValuesProvider.SetConfigValuesAsync(config, cancellationToken);
+        await configValuesProvider.SetConfigValuesAsync(cancellationToken);
         logger.LogInformation("Authentication tokens issued successfully.");
 
         return 0;

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -12,11 +12,12 @@ internal class LoginCommandHandler : ICommandHandler
     private readonly IDiscoveryCache discoveryCache;
     private readonly ILogger logger;
 
-    public LoginCommandHandler(FaluCliClient client, IHttpClientFactory httpClientFactory, ILogger<LoginCommandHandler> logger)
+    public LoginCommandHandler(FaluCliClient client, HttpClient httpClient, ILogger<LoginCommandHandler> logger)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
+        this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        httpClient = httpClientFactory?.CreateClient() ?? throw new ArgumentNullException(nameof(httpClientFactory));
+
         discoveryCache = new DiscoveryCache(Constants.Authority, () => httpClient);
     }
 

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -1,0 +1,21 @@
+﻿using Falu.Client;
+
+namespace Falu.Commands.Login;
+
+internal class LoginCommandHandler : ICommandHandler
+{
+    public FaluCliClient client;
+    private readonly ILogger logger;
+
+    public LoginCommandHandler(FaluCliClient client, ILogger<LoginCommandHandler> logger)
+    {
+        this.client = client ?? throw new ArgumentNullException(nameof(client));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<int> InvokeAsync(InvocationContext context)
+    {
+
+        return 0;
+    }
+}

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -35,14 +35,7 @@ internal class LoginCommandHandler : ICommandHandler
         logger.LogInformation("Authentication tokens issued successfully.");
 
         // save the authentication information
-        var config = await configValuesProvider.GetConfigValuesAsync(cancellationToken);
-        config.Authentication = new AuthenticationTokenConfigData
-        {
-            AccessToken = token_resp.AccessToken,
-            RefreshToken = token_resp.RefreshToken,
-            AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(token_resp.ExpiresIn).AddSeconds(-5),
-        };
-        await configValuesProvider.SaveConfigValuesAsync(cancellationToken);
+        await configValuesProvider.SaveConfigValuesAsync(token_resp, cancellationToken);
         logger.LogInformation("Authentication tokens issued successfully.");
 
         return 0;

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -1,21 +1,98 @@
 ﻿using Falu.Client;
+using IdentityModel;
+using IdentityModel.Client;
+using System.Diagnostics;
 
 namespace Falu.Commands.Login;
 
 internal class LoginCommandHandler : ICommandHandler
 {
     public FaluCliClient client;
+    private readonly HttpClient httpClient;
+    private readonly IDiscoveryCache discoveryCache;
     private readonly ILogger logger;
 
-    public LoginCommandHandler(FaluCliClient client, ILogger<LoginCommandHandler> logger)
+    public LoginCommandHandler(FaluCliClient client, IHttpClientFactory httpClientFactory, ILogger<LoginCommandHandler> logger)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        httpClient = httpClientFactory?.CreateClient() ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        discoveryCache = new DiscoveryCache(Constants.Authority, () => httpClient);
     }
 
     public async Task<int> InvokeAsync(InvocationContext context)
     {
+        var cancellationToken = context.GetCancellationToken();
+
+        // perform confirguration discovery
+        var disco = await discoveryCache.GetAsync();
+        if (disco.IsError) throw new LoginException(disco.Error, disco.Exception);
+
+        // perform device authorization
+        var auth_resp = await RequestAuthorizationAsync(disco, cancellationToken);
+
+        // get the token, (polling)
+        var token_resp = await RequestTokenAsync(disco, auth_resp, cancellationToken);
+        //token_resp.Show();
 
         return 0;
+    }
+
+    private async Task<DeviceAuthorizationResponse> RequestAuthorizationAsync(DiscoveryDocumentResponse disco, CancellationToken cancellationToken = default)
+    {
+        var request = new DeviceAuthorizationRequest
+        {
+            Address = disco.DeviceAuthorizationEndpoint,
+            ClientId = Constants.ClientId,
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            Scope = Constants.ScopeApi,
+        };
+        var response = await httpClient.RequestDeviceAuthorizationAsync(request, cancellationToken);
+        if (response.IsError) throw new LoginException(response.Error);
+
+        logger.LogInformation("Device authentication started. You need to complete this in the browser.");
+        logger.LogInformation("User code   : {UserCode}", response.UserCode);
+        logger.LogInformation("Device code : {DeviceCode}", response.DeviceCode);
+        logger.LogInformation("URL         : {VerificationUri}", response.VerificationUri);
+        //logger.LogInformation("Complete URL: {VerificationUriComplete}",response.VerificationUriComplete);
+
+        logger.LogInformation("");
+        logger.LogInformation("Press enter to launch browser ({VerificationUri})", response.VerificationUri);
+        Console.ReadLine();
+
+        Process.Start(new ProcessStartInfo(response.VerificationUriComplete) { UseShellExecute = true });
+
+        return response;
+    }
+
+    private async Task<TokenResponse> RequestTokenAsync(DiscoveryDocumentResponse disco, DeviceAuthorizationResponse auth, CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            var request = new DeviceTokenRequest
+            {
+                Address = disco.TokenEndpoint,
+                ClientId = Constants.ClientId,
+                DeviceCode = auth.DeviceCode,
+            };
+            var response = await httpClient.RequestDeviceTokenAsync(request, cancellationToken);
+
+            if (response.IsError)
+            {
+                if (response.Error == OidcConstants.TokenErrors.AuthorizationPending || response.Error == OidcConstants.TokenErrors.SlowDown)
+                {
+                    logger.LogInformation("{Error}... waiting.", response.Error);
+                    await Task.Delay(TimeSpan.FromSeconds(auth.Interval), cancellationToken);
+                }
+                else
+                {
+                    throw new LoginException(response.Error, response.Exception);
+                }
+            }
+            else
+            {
+                return response;
+            }
+        }
     }
 }

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -55,10 +55,11 @@ internal class LoginCommandHandler : ICommandHandler
         var response = await client.RequestDeviceAuthorizationAsync(request, cancellationToken);
         if (response.IsError) throw new LoginException(response.Error);
 
-        logger.LogInformation("Complete authentication in the browser using the following information:");
-        logger.LogInformation("User code   : {UserCode}", response.UserCode);
-        logger.LogInformation("Device code : {DeviceCode}", response.DeviceCode);
-        logger.LogInformation("Opening your browser at {VerificationUri}", response.VerificationUri);
+        var info = string.Join(Environment.NewLine,
+                               $"User code   : {response.UserCode}",
+                               $"Device code : {response.DeviceCode}",
+                               $"Opening your browser at {response.VerificationUri}");
+        logger.LogInformation("Complete authentication in the browser using the following information:{SignInInformation}", info);
 
         // delay for 2 seconds before opening the browser for the user to see the code
         await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -40,6 +40,8 @@ internal class LoginCommandHandler : ICommandHandler
 
     private async Task<DeviceAuthorizationResponse> RequestAuthorizationAsync(DiscoveryDocumentResponse disco, CancellationToken cancellationToken = default)
     {
+        logger.LogInformation("Performing device authentication. You will be redirected to the browser.");
+
         var request = new DeviceAuthorizationRequest
         {
             Address = disco.DeviceAuthorizationEndpoint,
@@ -50,15 +52,10 @@ internal class LoginCommandHandler : ICommandHandler
         var response = await httpClient.RequestDeviceAuthorizationAsync(request, cancellationToken);
         if (response.IsError) throw new LoginException(response.Error);
 
-        logger.LogInformation("Device authentication started. You need to complete this in the browser.");
+        logger.LogInformation("Complete authentication in the browser using the following information:");
         logger.LogInformation("User code   : {UserCode}", response.UserCode);
         logger.LogInformation("Device code : {DeviceCode}", response.DeviceCode);
-        logger.LogInformation("URL         : {VerificationUri}", response.VerificationUri);
-        //logger.LogInformation("Complete URL: {VerificationUriComplete}",response.VerificationUriComplete);
-
-        logger.LogInformation("");
-        logger.LogInformation("Press enter to launch browser ({VerificationUri})", response.VerificationUri);
-        Console.ReadLine();
+        logger.LogInformation("Opening your browser at {VerificationUri}", response.VerificationUri);
 
         Process.Start(new ProcessStartInfo(response.VerificationUriComplete) { UseShellExecute = true });
 

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -12,14 +12,12 @@ internal class LoginCommandHandler : ICommandHandler
     private readonly ILogger logger;
     private readonly IDiscoveryCache discoveryCache;
 
-    public LoginCommandHandler(IHttpClientFactory httpClientFactory, IConfigValuesProvider configValuesProvider, ILogger<LoginCommandHandler> logger)
+    public LoginCommandHandler(IHttpClientFactory httpClientFactory, IDiscoveryCache discoveryCache, IConfigValuesProvider configValuesProvider, ILogger<LoginCommandHandler> logger)
     {
-        // unfortunately, injecting does not work, instead if gives the default client instance
-        client = httpClientFactory?.CreateClient(nameof(LoginCommandHandler)) ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        client = httpClientFactory?.CreateOpenIdClient() ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        this.discoveryCache = discoveryCache ?? throw new ArgumentNullException(nameof(discoveryCache));
         this.configValuesProvider = configValuesProvider ?? throw new ArgumentNullException(nameof(configValuesProvider));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-        discoveryCache = new DiscoveryCache(Constants.Authority, () => client);
     }
 
     public async Task<int> InvokeAsync(InvocationContext context)

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -45,7 +45,7 @@ internal class LoginCommandHandler : ICommandHandler
             RefreshToken = token_resp.RefreshToken,
             AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(token_resp.ExpiresIn).AddSeconds(-5),
         };
-        await configValuesProvider.SetConfigValuesAsync(cancellationToken);
+        await configValuesProvider.SaveConfigValuesAsync(cancellationToken);
         logger.LogInformation("Authentication tokens issued successfully.");
 
         return 0;

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -25,8 +25,7 @@ internal class LoginCommandHandler : ICommandHandler
         var cancellationToken = context.GetCancellationToken();
 
         // perform confirguration discovery
-        var disco = await discoveryCache.GetAsync();
-        if (disco.IsError) throw new LoginException(disco.Error, disco.Exception);
+        var disco = await discoveryCache.GetSafelyAsync(cancellationToken);
 
         // perform device authorization
         var auth_resp = await RequestAuthorizationAsync(disco, cancellationToken);

--- a/src/FaluCli/Commands/Login/LoginException.cs
+++ b/src/FaluCli/Commands/Login/LoginException.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Falu.Commands.Login;
+
+[Serializable]
+public class LoginException : Exception
+{
+    public LoginException() { }
+    public LoginException(string message) : base(message) { }
+    public LoginException(string message, Exception inner) : base(message, inner) { }
+    protected LoginException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+}

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -24,4 +24,7 @@ internal record AuthenticationTokenConfigData
     public string? AccessToken { get; set; }
     public DateTimeOffset? AccessTokenExpiry { get; set; }
     public string? RefreshToken { get; set; }
+
+    public bool HasValidAccessToken() => !string.IsNullOrWhiteSpace(AccessToken) && AccessTokenExpiry > DateTimeOffset.UtcNow;
+    public bool HasValidRefreshToken() => !string.IsNullOrWhiteSpace(RefreshToken);
 }

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -1,10 +1,22 @@
-﻿namespace Falu.Config;
+﻿using IdentityModel.Client;
+
+namespace Falu.Config;
 
 internal record ConfigValues
 {
     public string? ActiveWorkspaceId { get; set; }
     public bool ActiveLiveMode { get; set; }
     public AuthenticationTokenConfigData? Authentication { get; set; }
+
+    public void Update(TokenResponse response)
+    {
+        Authentication = new AuthenticationTokenConfigData
+        {
+            AccessToken = response.AccessToken,
+            RefreshToken = response.RefreshToken,
+            AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn).AddSeconds(-5),
+        };
+    }
 }
 
 internal record AuthenticationTokenConfigData

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -1,0 +1,15 @@
+﻿namespace Falu.Config;
+
+internal record ConfigValues
+{
+    public string? ActiveWorkspaceId { get; set; }
+    public bool ActiveLiveMode { get; set; }
+    public AuthenticationTokenConfigData? Authentication { get; set; }
+}
+
+internal record AuthenticationTokenConfigData
+{
+    public string? AccessToken { get; set; }
+    public DateTimeOffset? AccessTokenExpiry { get; set; }
+    public string? RefreshToken { get; set; }
+}

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -10,16 +10,6 @@ internal class ConfigValuesProvider : IConfigValuesProvider
 
     private ConfigValues? values;
 
-    public ConfigValues GetConfigValues()
-    {
-        if (values is null)
-        {
-            var toml = File.ReadAllText(FilePath);
-            values = Tomlyn.Toml.ToModel<ConfigValues>(toml);
-        }
-        return values;
-    }
-
     public async ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default)
     {
         if (values is null)

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -35,7 +35,7 @@ internal class ConfigValuesProvider : IConfigValuesProvider
         return values;
     }
 
-    public async Task SetConfigValuesAsync(CancellationToken cancellationToken = default)
+    public async Task SaveConfigValuesAsync(CancellationToken cancellationToken = default)
     {
         values ??= await GetConfigValuesAsync(cancellationToken);
         var toml = Tomlyn.Toml.FromModel(values);

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace Falu.Config;
+﻿using IdentityModel.Client;
+
+namespace Falu.Config;
 
 internal class ConfigValuesProvider : IConfigValuesProvider
 {
@@ -40,5 +42,13 @@ internal class ConfigValuesProvider : IConfigValuesProvider
         values ??= await GetConfigValuesAsync(cancellationToken);
         var toml = Tomlyn.Toml.FromModel(values);
         await File.WriteAllTextAsync(FilePath, toml, cancellationToken);
+    }
+
+    public async Task SaveConfigValuesAsync(TokenResponse response, CancellationToken cancellationToken = default)
+    {
+        values ??= await GetConfigValuesAsync(cancellationToken);
+        values.Update(response);
+
+        await SaveConfigValuesAsync(cancellationToken);
     }
 }

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -22,8 +22,15 @@ internal class ConfigValuesProvider : IConfigValuesProvider
     {
         if (values is null)
         {
-            var toml = await File.ReadAllTextAsync(FilePath, cancellationToken);
-            values = Tomlyn.Toml.ToModel<ConfigValues>(toml);
+            if (File.Exists(FilePath))
+            {
+                var toml = await File.ReadAllTextAsync(FilePath, cancellationToken);
+                values = Tomlyn.Toml.ToModel<ConfigValues>(toml);
+            }
+            else
+            {
+                values = new ConfigValues();
+            }
         }
         return values;
     }

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -28,9 +28,9 @@ internal class ConfigValuesProvider : IConfigValuesProvider
         return values;
     }
 
-    public async Task SetConfigValuesAsync(ConfigValues values, CancellationToken cancellationToken = default)
+    public async Task SetConfigValuesAsync(CancellationToken cancellationToken = default)
     {
-        Interlocked.Exchange(ref this.values, values);
+        values ??= await GetConfigValuesAsync(cancellationToken);
         var toml = Tomlyn.Toml.FromModel(values);
         await File.WriteAllTextAsync(FilePath, toml, cancellationToken);
     }

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -1,0 +1,37 @@
+﻿namespace Falu.Config;
+
+internal class ConfigValuesProvider : IConfigValuesProvider
+{
+    // Path example C:\Users\USERNAME\.config\falu\config.toml
+    private static readonly string UserProfileFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    private static readonly string FilePath = Path.Combine(UserProfileFolder, ".config", "falu", "config.toml");
+
+    private ConfigValues? values;
+
+    public ConfigValues GetConfigValues()
+    {
+        if (values is null)
+        {
+            var toml = File.ReadAllText(FilePath);
+            values = Tomlyn.Toml.ToModel<ConfigValues>(toml);
+        }
+        return values;
+    }
+
+    public async ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default)
+    {
+        if (values is null)
+        {
+            var toml = await File.ReadAllTextAsync(FilePath, cancellationToken);
+            values = Tomlyn.Toml.ToModel<ConfigValues>(toml);
+        }
+        return values;
+    }
+
+    public async Task SetConfigValuesAsync(ConfigValues values, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Exchange(ref this.values, values);
+        var toml = Tomlyn.Toml.FromModel(values);
+        await File.WriteAllTextAsync(FilePath, toml, cancellationToken);
+    }
+}

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -4,7 +4,6 @@ namespace Falu.Config;
 
 internal interface IConfigValuesProvider
 {
-    ConfigValues GetConfigValues();
     ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
     Task SaveConfigValuesAsync(CancellationToken cancellationToken = default);
     Task SaveConfigValuesAsync(TokenResponse response, CancellationToken cancellationToken = default);

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace Falu.Config;
+
+internal interface IConfigValuesProvider
+{
+    ConfigValues GetConfigValues();
+    ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
+    Task SetConfigValuesAsync(ConfigValues values, CancellationToken cancellationToken = default);
+}

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -4,5 +4,5 @@ internal interface IConfigValuesProvider
 {
     ConfigValues GetConfigValues();
     ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
-    Task SetConfigValuesAsync(ConfigValues values, CancellationToken cancellationToken = default);
+    Task SetConfigValuesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -4,5 +4,5 @@ internal interface IConfigValuesProvider
 {
     ConfigValues GetConfigValues();
     ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
-    Task SetConfigValuesAsync(CancellationToken cancellationToken = default);
+    Task SaveConfigValuesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -1,8 +1,11 @@
-﻿namespace Falu.Config;
+﻿using IdentityModel.Client;
+
+namespace Falu.Config;
 
 internal interface IConfigValuesProvider
 {
     ConfigValues GetConfigValues();
     ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
     Task SaveConfigValuesAsync(CancellationToken cancellationToken = default);
+    Task SaveConfigValuesAsync(TokenResponse response, CancellationToken cancellationToken = default);
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -2,7 +2,9 @@
 
 internal class Constants
 {
-    public const string OpenIdHttpClientName = "OpenIdClient";
+    public const string OpenIdCategoryOrClientName = "Oidc";
+
+    public const string DefaultApiKey = "default-api-key";
 
     public const string RepositoryOwner = "tinglesoftware";
     public const string RepositoryName = "falu-cli";

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -2,6 +2,8 @@
 
 internal class Constants
 {
+    public const string OpenIdHttpClientName = "OpenIdClient";
+
     public const string RepositoryOwner = "tinglesoftware";
     public const string RepositoryName = "falu-cli";
 

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Falu;
+
+internal class Constants
+{
+    public const string RepositoryOwner = "tinglesoftware";
+    public const string RepositoryName = "falu-cli";
+}

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -4,4 +4,8 @@ internal class Constants
 {
     public const string RepositoryOwner = "tinglesoftware";
     public const string RepositoryName = "falu-cli";
+
+    public const string Authority = "https://login.falu.io";
+    public const string ScopeApi = "https://api.falu.io/";
+    public const string ClientId = "device";
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -6,13 +6,13 @@ internal class Constants
     public const string RepositoryName = "falu-cli";
 
     public const string Authority = "https://login.falu.io";
-    public const string ScopeApi = "https://api.falu.io/";
+    public const string ScopeApi = "api";
     public const string ClientId = "device";
-    public static readonly ICollection<string> ScopesList =new HashSet<string>
+    public static readonly ICollection<string> ScopesList = new HashSet<string>
     {
         IdentityModel.OidcConstants.StandardScopes.OpenId,
         IdentityModel.OidcConstants.StandardScopes.OfflineAccess,
-        ScopeApi
+        ScopeApi,
     };
     public static readonly string Scopes = string.Join(" ", ScopesList);
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -7,7 +7,7 @@ internal class Constants
 
     public const string Authority = "https://login.falu.io";
     public const string ScopeApi = "api";
-    public const string ClientId = "device";
+    public const string ClientId = "cli";
     public static readonly ICollection<string> ScopesList = new HashSet<string>
     {
         IdentityModel.OidcConstants.StandardScopes.OpenId,

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -8,4 +8,11 @@ internal class Constants
     public const string Authority = "https://login.falu.io";
     public const string ScopeApi = "https://api.falu.io/";
     public const string ClientId = "device";
+    public static readonly ICollection<string> ScopesList =new HashSet<string>
+    {
+        IdentityModel.OidcConstants.StandardScopes.OpenId,
+        IdentityModel.OidcConstants.StandardScopes.OfflineAccess,
+        ScopeApi
+    };
+    public static readonly string Scopes = string.Join(" ", ScopesList);
 }

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -180,8 +180,7 @@ public static class CommandExtensions
 
         // TODO: validate api key using regex -> "^{sk|pk}_{live|test}_[0-9a-zA-Z]+$"
         command.AddGlobalOption<string>(aliases: new[] { "-k", "--apikey", },
-                                        description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...",
-                                        configure: o => o.IsRequired = true);
+                                        description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...");
 
         command.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);
 

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -180,7 +180,7 @@ public static class CommandExtensions
 
         // TODO: validate api key using regex -> "^{sk|pk}_{live|test}_[0-9a-zA-Z]+$"
         command.AddGlobalOption<string>(aliases: new[] { "-k", "--apikey", },
-                                        description: "The identifier of the workspace being accessed. Required when loggin is by user account. Looks like: sk_test_LdVyn0upN...",
+                                        description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...",
                                         configure: o => o.IsRequired = true);
 
         command.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);

--- a/src/FaluCli/Extensions/CommandLineBuilderExtensions.cs
+++ b/src/FaluCli/Extensions/CommandLineBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Falu;
+using Falu.Commands.Login;
 using Falu.Updates;
 using System.CommandLine.IO;
 using System.Net;
@@ -71,6 +72,10 @@ internal static class CommandLineBuilderExtensions
             {
                 stderr.WriteLine(fe.Message);
             }
+        }
+        else if (exception is LoginException le)
+        {
+            stderr.WriteLine(Res.LoginFailedFormat, le.Message);
         }
         else
         {

--- a/src/FaluCli/Extensions/IDiscoveryCacheExtensions.cs
+++ b/src/FaluCli/Extensions/IDiscoveryCacheExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Falu.Commands.Login;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client;
+
+internal static class IDiscoveryCacheExtensions
+{
+    public static async Task<DiscoveryDocumentResponse> GetSafelyAsync(this IDiscoveryCache cache, CancellationToken cancellationToken = default)
+    {
+        var response = await cache.GetAsync();
+        if (response.IsError) throw new LoginException(response.Error, response.Exception);
+
+        return response;
+    }
+}

--- a/src/FaluCli/Extensions/IHttpClientFactoryExtensions.cs
+++ b/src/FaluCli/Extensions/IHttpClientFactoryExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Falu;
+
+namespace System.Net.Http;
+
+internal static class IHttpClientFactoryExtensions
+{
+    public static HttpClient CreateOpenIdClient(this IHttpClientFactory factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory, nameof(factory));
+        return factory.CreateClient(Constants.OpenIdHttpClientName);
+    }
+}

--- a/src/FaluCli/Extensions/IHttpClientFactoryExtensions.cs
+++ b/src/FaluCli/Extensions/IHttpClientFactoryExtensions.cs
@@ -7,6 +7,6 @@ internal static class IHttpClientFactoryExtensions
     public static HttpClient CreateOpenIdClient(this IHttpClientFactory factory)
     {
         ArgumentNullException.ThrowIfNull(factory, nameof(factory));
-        return factory.CreateClient(Constants.OpenIdHttpClientName);
+        return factory.CreateClient(Constants.OpenIdCategoryOrClientName);
     }
 }

--- a/src/FaluCli/Extensions/ILoggerFactoryExtensions.cs
+++ b/src/FaluCli/Extensions/ILoggerFactoryExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Falu;
+
+namespace Microsoft.Extensions.Logging;
+
+internal static class ILoggerFactoryExtensions
+{
+    public static ILogger CreateOpenIdLogger(this ILoggerFactory factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory, nameof(factory));
+        return factory.CreateLogger(Constants.OpenIdCategoryOrClientName);
+    }
+}

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ internal static class IServiceCollectionExtensions
                     client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("falucli", VersioningHelper.ProductVersion));
                 });
 
-        services.AddSingleton<IConfigureOptions<FaluClientOptions>, ConfigureFaluClientOptions>();
+        services.ConfigureOptions<FaluClientConfigureOptions>();
 
         return services;
     }
@@ -31,11 +31,11 @@ internal static class IServiceCollectionExtensions
         return services;
     }
 
-    internal class ConfigureFaluClientOptions : IConfigureOptions<FaluClientOptions>
+    internal class FaluClientConfigureOptions : IConfigureOptions<FaluClientOptions>
     {
         private readonly InvocationContext context;
 
-        public ConfigureFaluClientOptions(InvocationContext context)
+        public FaluClientConfigureOptions(InvocationContext context)
         {
             this.context = context ?? throw new ArgumentNullException(nameof(context));
         }

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -19,8 +19,10 @@ internal static class IServiceCollectionExtensions
                     // change the User-Agent header
                     client.DefaultRequestHeaders.UserAgent.Clear();
                     client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("falucli", VersioningHelper.ProductVersion));
-                });
+                })
+                .AddHttpMessageHandler<HttpAuthenticationHandler>();
 
+        services.AddScoped<HttpAuthenticationHandler>();
         services.ConfigureOptions<FaluClientConfigureOptions>();
 
         return services;
@@ -38,7 +40,7 @@ internal static class IServiceCollectionExtensions
 
     public static IServiceCollection AddOpenIdServices(this IServiceCollection services)
     {
-        services.AddHttpClient(Constants.OpenIdHttpClientName);
+        services.AddHttpClient(Constants.OpenIdCategoryOrClientName);
 
         services.AddScoped<IDiscoveryCache>(p =>
         {
@@ -52,17 +54,9 @@ internal static class IServiceCollectionExtensions
 
     internal class FaluClientConfigureOptions : IConfigureOptions<FaluClientOptions>
     {
-        private readonly InvocationContext context;
-
-        public FaluClientConfigureOptions(InvocationContext context)
-        {
-            this.context = context ?? throw new ArgumentNullException(nameof(context));
-        }
-
         public void Configure(FaluClientOptions options)
         {
-            // TODO: pull from stored configuration
-            options.ApiKey = context.ParseResult.ValueForOption<string>("--apikey");
+            options.ApiKey = Constants.DefaultApiKey;
         }
     }
 }

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Falu.Client;
 using Falu.Config;
 using Falu.Updates;
+using IdentityModel.Client;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Headers;
 
@@ -33,6 +34,20 @@ internal static class IServiceCollectionExtensions
     public static IServiceCollection AddConfigValuesProvider(this IServiceCollection services)
     {
         return services.AddScoped<IConfigValuesProvider, ConfigValuesProvider>();
+    }
+
+    public static IServiceCollection AddOpenIdServices(this IServiceCollection services)
+    {
+        services.AddHttpClient(Constants.OpenIdHttpClientName);
+
+        services.AddScoped<IDiscoveryCache>(p =>
+        {
+            var httpClientFactory = p.GetRequiredService<IHttpClientFactory>();
+            var client = httpClientFactory.CreateOpenIdClient();
+            return new DiscoveryCache(Constants.Authority, () => client);
+        });
+
+        return services;
     }
 
     internal class FaluClientConfigureOptions : IConfigureOptions<FaluClientOptions>

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Falu;
 using Falu.Client;
+using Falu.Config;
 using Falu.Updates;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Headers;
@@ -26,9 +27,12 @@ internal static class IServiceCollectionExtensions
 
     public static IServiceCollection AddUpdateChecker(this IServiceCollection services)
     {
-        services.AddHostedService<UpdateChecker>();
+        return services.AddHostedService<UpdateChecker>();
+    }
 
-        return services;
+    public static IServiceCollection AddConfigValuesProvider(this IServiceCollection services)
+    {
+        return services.AddScoped<IConfigValuesProvider, ConfigValuesProvider>();
     }
 
     internal class FaluClientConfigureOptions : IConfigureOptions<FaluClientOptions>

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ internal static class IServiceCollectionExtensions
 
         public void Configure(FaluClientOptions options)
         {
+            // TODO: pull from stored configuration
             options.ApiKey = context.ParseResult.ValueForOption<string>("--apikey");
         }
     }

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Falu" Version="1.0.0" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="Tomlyn" Version="0.14.1" />
   </ItemGroup>
 
 </Project>

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -56,7 +56,7 @@ var builder = new CommandLineBuilder(rootCommand)
 
                 // See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#logging
                 ["Logging:LogLevel:System.Net.Http.HttpClient"] = "None", // removes all we do not need
-                ["Logging:LogLevel:System.Net.Http.HttpClient.LoginCommandHandler.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
+                ["Logging:LogLevel:System.Net.Http.HttpClient.OpenIdClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
                 ["Logging:LogLevel:System.Net.Http.HttpClient.FaluCliClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
 
                 ["Logging:Console:FormatterName"] = "Falu",
@@ -77,7 +77,7 @@ var builder = new CommandLineBuilder(rootCommand)
             var configuration = context.Configuration;
             services.AddFaluClientForCli();
             services.AddUpdateChecker();
-            services.AddHttpClient<LoginCommandHandler>();
+            services.AddOpenIdServices();
         });
 
         host.UseCommandHandler<LoginCommand, LoginCommandHandler>();

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Falu.Commands.Events;
+using Falu.Commands.Login;
 using Falu.Commands.Templates;
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
@@ -7,6 +8,8 @@ using System.CommandLine.Parsing;
 // Create a root command with some options
 var rootCommand = new RootCommand
 {
+    new LoginCommand(),
+
     new Command("evaluations", "Manage evaluations.")
     {
     },
@@ -75,6 +78,7 @@ var builder = new CommandLineBuilder(rootCommand)
             services.AddUpdateChecker();
         });
 
+        host.UseCommandHandler<LoginCommand, LoginCommandHandler>();
         host.UseCommandHandler<RetryCommand, RetryCommandHandler>();
         host.UseCommandHandler<PullTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<PushTemplatesCommand, TemplatesCommandHandler>();

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -77,6 +77,7 @@ var builder = new CommandLineBuilder(rootCommand)
             var configuration = context.Configuration;
             services.AddFaluClientForCli();
             services.AddUpdateChecker();
+            services.AddConfigValuesProvider();
             services.AddOpenIdServices();
         });
 

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -56,7 +56,8 @@ var builder = new CommandLineBuilder(rootCommand)
 
                 // See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#logging
                 ["Logging:LogLevel:System.Net.Http.HttpClient"] = "None", // removes all we do not need
-                ["Logging:LogLevel:System.Net.Http.HttpClient.FaluCliClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add the one we need
+                ["Logging:LogLevel:System.Net.Http.HttpClient.LoginCommandHandler.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
+                ["Logging:LogLevel:System.Net.Http.HttpClient.FaluCliClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
 
                 ["Logging:Console:FormatterName"] = "Falu",
                 ["Logging:Console:FormatterOptions:SingleLine"] = verbose ? "False" : "True",

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -56,7 +56,7 @@ var builder = new CommandLineBuilder(rootCommand)
 
                 // See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#logging
                 ["Logging:LogLevel:System.Net.Http.HttpClient"] = "None", // removes all we do not need
-                ["Logging:LogLevel:System.Net.Http.HttpClient.OpenIdClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
+                ["Logging:LogLevel:System.Net.Http.HttpClient.Oidc.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
                 ["Logging:LogLevel:System.Net.Http.HttpClient.FaluCliClient.ClientHandler"] = verbose ? "Trace" : "Warning", // add what we need
 
                 ["Logging:Console:FormatterName"] = "Falu",

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -76,6 +76,7 @@ var builder = new CommandLineBuilder(rootCommand)
             var configuration = context.Configuration;
             services.AddFaluClientForCli();
             services.AddUpdateChecker();
+            services.AddHttpClient<LoginCommandHandler>();
         });
 
         host.UseCommandHandler<LoginCommand, LoginCommandHandler>();

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -71,6 +71,15 @@ namespace Falu.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Login request failed with code: {0}.
+        /// </summary>
+        internal static string LoginFailedFormat {
+            get {
+                return ResourceManager.GetString("LoginFailedFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error Code: {0}.
         /// </summary>
         internal static string ProblemDetailsErrorCodeFormat {

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -122,6 +122,10 @@
 Consult your Falu dashboard to confirm the permissions of the API key or ask your administrator to grant you permissions.</value>
     <comment>Error message to display for HTTP 403 (Forbidden) responses.</comment>
   </data>
+  <data name="LoginFailedFormat" xml:space="preserve">
+    <value>Login request failed with code: {0}</value>
+    <comment>Error message to display failed login/OIDC responses.</comment>
+  </data>
   <data name="ProblemDetailsErrorCodeFormat" xml:space="preserve">
     <value>Error Code: {0}</value>
   </data>

--- a/src/FaluCli/Updates/UpdateChecker.cs
+++ b/src/FaluCli/Updates/UpdateChecker.cs
@@ -4,9 +4,6 @@ namespace Falu.Updates;
 
 internal class UpdateChecker : BackgroundService
 {
-    public const string RepositoryOwner = "tinglesoftware";
-    public const string RepositoryName = "falu-cli";
-
     private static readonly SemaphoreSlim locker = new(1);
     private static readonly SemanticVersioning.Version? currentVersion = SemanticVersioning.Version.Parse(VersioningHelper.ProductVersion);
     private static SemanticVersioning.Version? latestVersion;
@@ -27,9 +24,9 @@ internal class UpdateChecker : BackgroundService
 
             try
             {
-                var client = new GitHubClient(new ProductHeaderValue(RepositoryName));
+                var client = new GitHubClient(new ProductHeaderValue(Constants.RepositoryName));
                 await locker.WaitAsync(stoppingToken);
-                var release = await client.Repository.Release.GetLatest(RepositoryOwner, RepositoryName);
+                var release = await client.Repository.Release.GetLatest(Constants.RepositoryOwner, Constants.RepositoryName);
                 Interlocked.Exchange(ref latestVersion, SemanticVersioning.Version.Parse(release.TagName));
                 Interlocked.Exchange(ref latestVersionHtmlUrl, release.HtmlUrl);
             }


### PR DESCRIPTION
Alongside using an API Key, users can authenticate using a bearer token. The latter form of authentication is required for certain operations. It is the recommended means of authentication for CLI users for undocumented API operations.