### PR TITLE
Better input validation

### DIFF
--- a/FaluCli.sln
+++ b/FaluCli.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{03C404AC
 		tests\Directory.Build.props = tests\Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FaluCli.Tests", "tests\FaluCli.Tests\FaluCli.Tests.csproj", "{B975D593-4EBF-41C8-BF36-B124B9D1A86B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,12 +27,17 @@ Global
 		{FE48265D-93DF-4B00-9EFD-A8DB2815CA2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE48265D-93DF-4B00-9EFD-A8DB2815CA2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE48265D-93DF-4B00-9EFD-A8DB2815CA2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B975D593-4EBF-41C8-BF36-B124B9D1A86B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B975D593-4EBF-41C8-BF36-B124B9D1A86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B975D593-4EBF-41C8-BF36-B124B9D1A86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B975D593-4EBF-41C8-BF36-B124B9D1A86B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE48265D-93DF-4B00-9EFD-A8DB2815CA2B} = {08B40617-9B88-4F7E-A294-1365BE71D353}
+		{B975D593-4EBF-41C8-BF36-B124B9D1A86B} = {03C404AC-4BD7-48D3-8973-07AAC9F1D84B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {74F859A4-C759-4A66-B464-23D4F3FC20CA}

--- a/src/FaluCli/Commands/Events/RetryCommand.cs
+++ b/src/FaluCli/Commands/Events/RetryCommand.cs
@@ -4,13 +4,13 @@ internal class RetryCommand : Command
 {
     public RetryCommand() : base("retry", "Retry delivery of an event to a webhook endpoint.")
     {
-        // TODO: validate eventId using regex -> "^evt_[0-9a-f]{24}$"
-        this.AddArgument<string>(name: "event",
-                                 description: "Unique identifier of the event. Example: evt_610010be9228355f14ce6e08");
+        this.AddArgument(name: "event",
+                         description: "Unique identifier of the event. Example: evt_610010be9228355f14ce6e08",
+                         format: Constants.EventIdFormat);
 
-        // TODO: validate webhookEndpointId using regex -> "^we_[0-9a-f]{24}$"
-        this.AddOption<string>(aliases: new[] { "--webhook-endpoint" },
-                               description: "Unique identifier of the webhook endpoint. Example: we_610010be9228355f14ce6e08",
-                               configure: o => o.IsRequired = true);
+        this.AddOption(aliases: new[] { "--webhook-endpoint" },
+                       description: "Unique identifier of the webhook endpoint. Example: we_610010be9228355f14ce6e08",
+                       format: Constants.WebhookEndpointIdFormat,
+                       configure: o => o.IsRequired = true);
     }
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -24,4 +24,8 @@ internal class Constants
     public static readonly string MaxMpesaStatementFileSizeString = MaxMpesaStatementFileSize.ToBinaryString();
 
     public static readonly Regex ObjectIdFormat = new(@"^[a-z]{2,7}_[a-zA-Z0-9]{20,30}$");
+    public static readonly Regex EventIdFormat = new(@"^evt_[a-zA-Z0-9]{20,30}$");
+    public static readonly Regex WorkspaceIdFormat = new(@"^wksp_[a-zA-Z0-9]{20,30}$");
+    public static readonly Regex ApiKeyFormat = new(@"^{sk|pk}_{live|test}_[0-9a-zA-Z]{20,30}$");
+    public static readonly Regex WebhookEndpointIdFormat = new(@"^we_[a-zA-Z0-9]{20,30}$");
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Falu;
+﻿using System.Text.RegularExpressions;
+
+namespace Falu;
 
 internal class Constants
 {
@@ -20,4 +22,6 @@ internal class Constants
 
     public static readonly ByteSizeLib.ByteSize MaxMpesaStatementFileSize = ByteSizeLib.ByteSize.FromKibiBytes(128);
     public static readonly string MaxMpesaStatementFileSizeString = MaxMpesaStatementFileSize.ToBinaryString();
+
+    public static readonly Regex ObjectIdFormat = new(@"^[a-z]{2,7}_[a-zA-Z0-9]{20,30}$");
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -24,7 +24,7 @@ internal class Constants
     public static readonly string MaxMpesaStatementFileSizeString = MaxMpesaStatementFileSize.ToBinaryString();
 
     public static readonly Regex WorkspaceIdFormat = new(@"^wksp_[a-zA-Z0-9]{20,30}$");
-    public static readonly Regex ApiKeyFormat = new(@"^{sk|pk}_{live|test}_[0-9a-zA-Z]{20,30}$");
+    public static readonly Regex ApiKeyFormat = new(@"^^[s|p]k_(?:live|test)_[0-9a-zA-Z]{20,30}$");
     public static readonly Regex EventIdFormat = new(@"^evt_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex WebhookEndpointIdFormat = new(@"^we_[a-zA-Z0-9]{20,30}$");
 }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -23,9 +23,8 @@ internal class Constants
     public static readonly ByteSizeLib.ByteSize MaxMpesaStatementFileSize = ByteSizeLib.ByteSize.FromKibiBytes(128);
     public static readonly string MaxMpesaStatementFileSizeString = MaxMpesaStatementFileSize.ToBinaryString();
 
-    public static readonly Regex ObjectIdFormat = new(@"^[a-z]{2,7}_[a-zA-Z0-9]{20,30}$");
-    public static readonly Regex EventIdFormat = new(@"^evt_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex WorkspaceIdFormat = new(@"^wksp_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex ApiKeyFormat = new(@"^{sk|pk}_{live|test}_[0-9a-zA-Z]{20,30}$");
+    public static readonly Regex EventIdFormat = new(@"^evt_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex WebhookEndpointIdFormat = new(@"^we_[a-zA-Z0-9]{20,30}$");
 }

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using Falu;
+using System.Text.RegularExpressions;
 using Res = Falu.Properties.Resources;
 
 namespace System.CommandLine;
@@ -238,16 +239,16 @@ public static class CommandExtensions
 
     public static Command AddCommonGlobalOptions(this Command command)
     {
-        // TODO: validate workspaceId using regex -> "^wksp_[0-9a-f]{24}$"
-        command.AddGlobalOption<string>(aliases: new[] { "--workspace", },
-                                        description: "The identifier of the workspace being accessed. Required when login is by user account. Example: wksp_610010be9228355f14ce6e08");
+        command.AddGlobalOption(aliases: new[] { "--workspace", },
+                                description: "The identifier of the workspace being accessed. Required when login is by user account. Example: wksp_610010be9228355f14ce6e08",
+                                format: Constants.WorkspaceIdFormat);
 
         command.AddGlobalOption<bool>(aliases: new[] { "--live", },
                                       description: "Whether the entity resides in live mode or not. Required when login is by user account.");
 
-        // TODO: validate api key using regex -> "^{sk|pk}_{live|test}_[0-9a-zA-Z]+$"
-        command.AddGlobalOption<string>(aliases: new[] { "-k", "--apikey", },
-                                        description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...");
+        command.AddGlobalOption(aliases: new[] { "-k", "--apikey", },
+                                description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...",
+                                format: Constants.ApiKeyFormat);
 
         command.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);
 

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace System.CommandLine;
+﻿using System.Text.RegularExpressions;
+using Res = Falu.Properties.Resources;
+
+namespace System.CommandLine;
 
 /// <summary>
 /// Extension methods on <see cref="Command"/>.
@@ -6,6 +9,28 @@
 public static class CommandExtensions
 {
     #region Options
+
+    ///
+    public static Command AddOption(this Command command,
+                                    IEnumerable<string> aliases,
+                                    string? description = null,
+                                    Regex? format = null,
+                                    Action<Option<string>>? configure = null)
+    {
+        ValidateSymbolResult<OptionResult>? validate = null;
+        if (format is not null)
+        {
+            validate = (ar) =>
+            {
+                var value = ar.GetValueOrDefault<string>();
+                if (value is null || !format.IsMatch(value))
+                {
+                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                }
+            };
+        }
+        return command.AddOption(aliases, description, validate, configure);
+    }
 
     ///
     public static Command AddOption<T>(this Command command,
@@ -67,6 +92,28 @@ public static class CommandExtensions
     }
 
     ///
+    public static Command AddGlobalOption(this Command command,
+                                          IEnumerable<string> aliases,
+                                          string? description = null,
+                                          Regex? format = null,
+                                          Action<Option<string>>? configure = null)
+    {
+        ValidateSymbolResult<OptionResult>? validate = null;
+        if (format is not null)
+        {
+            validate = (ar) =>
+            {
+                var value = ar.GetValueOrDefault<string>();
+                if (value is null || !format.IsMatch(value))
+                {
+                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                }
+            };
+        }
+        return command.AddGlobalOption(aliases, description, validate, configure);
+    }
+
+    ///
     public static Command AddGlobalOption<T>(this Command command,
                                              IEnumerable<string> aliases,
                                              string? description = null,
@@ -106,6 +153,28 @@ public static class CommandExtensions
     #endregion
 
     #region Arguments
+
+    ///
+    public static Command AddArgument(this Command command,
+                                      string name,
+                                      string? description = null,
+                                      Regex? format = null,
+                                      Action<Argument<string>>? configure = null)
+    {
+        ValidateSymbolResult<ArgumentResult>? validate = null;
+        if (format is not null)
+        {
+            validate = (ar) =>
+            {
+                var value = ar.GetValueOrDefault<string>();
+                if (value is null || !format.IsMatch(value))
+                {
+                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                }
+            };
+        }
+        return command.AddArgument(name, description, validate, configure);
+    }
 
     ///
     public static Command AddArgument<T>(this Command command,

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -21,12 +21,12 @@ public static class CommandExtensions
         ValidateSymbolResult<OptionResult>? validate = null;
         if (format is not null)
         {
-            validate = (ar) =>
+            validate = (or) =>
             {
-                var value = ar.GetValueOrDefault<string>();
+                var value = or.GetValueOrDefault<string>();
                 if (value is null || !format.IsMatch(value))
                 {
-                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                    or.ErrorMessage = string.Format(Res.InvalidInputValue, or.Option.Name, format);
                 }
             };
         }
@@ -102,12 +102,12 @@ public static class CommandExtensions
         ValidateSymbolResult<OptionResult>? validate = null;
         if (format is not null)
         {
-            validate = (ar) =>
+            validate = (or) =>
             {
-                var value = ar.GetValueOrDefault<string>();
+                var value = or.GetValueOrDefault<string>();
                 if (value is null || !format.IsMatch(value))
                 {
-                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                    or.ErrorMessage = string.Format(Res.InvalidInputValue, or.Option.Name, format);
                 }
             };
         }
@@ -170,7 +170,7 @@ public static class CommandExtensions
                 var value = ar.GetValueOrDefault<string>();
                 if (value is null || !format.IsMatch(value))
                 {
-                    ar.ErrorMessage = string.Format(Res.InvalidInputFormat, format);
+                    ar.ErrorMessage = string.Format(Res.InvalidInputValue, ar.Argument.Name, format);
                 }
             };
         }

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
     <PackageReference Include="Tomlyn" Version="0.14.1" />
   </ItemGroup>
 

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="FaluCli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
     <PackageReference Include="Falu" Version="1.0.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -81,6 +81,15 @@ namespace Falu.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Input has invalid format. The expected pattern is &apos;{0}&apos;.
+        /// </summary>
+        internal static string InvalidInputFormat {
+            get {
+                return ResourceManager.GetString("InvalidInputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Login request failed! {0}.
         /// </summary>
         internal static string LoginFailedFormat {

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -81,11 +81,11 @@ namespace Falu.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Input has invalid format. The expected pattern is &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Value for &apos;{0}&apos; has invalid format. The expected pattern is &apos;{1}&apos;.
         /// </summary>
-        internal static string InvalidInputFormat {
+        internal static string InvalidInputValue {
             get {
-                return ResourceManager.GetString("InvalidInputFormat", resourceCulture);
+                return ResourceManager.GetString("InvalidInputValue", resourceCulture);
             }
         }
         

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -126,8 +126,8 @@ Either pass an API key via --apikey option or perform login via 'falu login' com
 Consult your Falu dashboard to confirm the permissions of the API key or ask your administrator to grant you permissions.</value>
     <comment>Error message to display for HTTP 403 (Forbidden) responses.</comment>
   </data>
-  <data name="InvalidInputFormat" xml:space="preserve">
-    <value>Input has invalid format. The expected pattern is '{0}'</value>
+  <data name="InvalidInputValue" xml:space="preserve">
+    <value>Value for '{0}' has invalid format. The expected pattern is '{1}'</value>
   </data>
   <data name="LoginFailedFormat" xml:space="preserve">
     <value>Login request failed! {0}</value>

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -126,6 +126,9 @@ Either pass an API key via --apikey option or perform login via 'falu login' com
 Consult your Falu dashboard to confirm the permissions of the API key or ask your administrator to grant you permissions.</value>
     <comment>Error message to display for HTTP 403 (Forbidden) responses.</comment>
   </data>
+  <data name="InvalidInputFormat" xml:space="preserve">
+    <value>Input has invalid format. The expected pattern is '{0}'</value>
+  </data>
   <data name="LoginFailedFormat" xml:space="preserve">
     <value>Login request failed! {0}</value>
     <comment>Error message to display failed login/OIDC responses.</comment>

--- a/tests/FaluCli.Tests/ConstantsTests.cs
+++ b/tests/FaluCli.Tests/ConstantsTests.cs
@@ -1,0 +1,12 @@
+﻿using Xunit;
+
+namespace Falu.Tests;
+
+public class ConstantsTests
+{
+    [Fact]
+    public void MaxMpesaStatementFileSizeString_IsCorrect()
+    {
+        Assert.Equal("128 KiB", Constants.MaxMpesaStatementFileSizeString);
+    }
+}

--- a/tests/FaluCli.Tests/ConstantsTests.cs
+++ b/tests/FaluCli.Tests/ConstantsTests.cs
@@ -12,10 +12,38 @@ public class ConstantsTests
 
     [Theory]
     [InlineData("wksp_602cd2747409e867a240d000")]
-    [InlineData("tr_60ffe3f79c1deb8060f91312")]
-    [InlineData("mtmpl_27e868O6xW4NYrQb3WvxDb8iW6D")]
-    public void ObjectIdFormat_IsCorrect(string input)
+    [InlineData("wksp_60ffe3f79c1deb8060f91312")]
+    [InlineData("wksp_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    public void WorkspaceIdFormat_IsCorrect(string input)
     {
-        Assert.Matches(Constants.ObjectIdFormat, input);
+        Assert.Matches(Constants.WorkspaceIdFormat, input);
+    }
+
+    [Theory]
+    [InlineData("sk_live_602cd2747409e867a240d000")]
+    [InlineData("sk_test_60ffe3f79c1deb8060f91312")]
+    [InlineData("pk_test_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    [InlineData("pk_live_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    public void ApiKeyFormat_IsCorrect(string input)
+    {
+        Assert.Matches(Constants.ApiKeyFormat, input);
+    }
+
+    [Theory]
+    [InlineData("evt_602cd2747409e867a240d000")]
+    [InlineData("evt_60ffe3f79c1deb8060f91312")]
+    [InlineData("evt_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    public void EventIdFormat_IsCorrect(string input)
+    {
+        Assert.Matches(Constants.EventIdFormat, input);
+    }
+
+    [Theory]
+    [InlineData("we_602cd2747409e867a240d000")]
+    [InlineData("we_60ffe3f79c1deb8060f91312")]
+    [InlineData("we_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    public void WebhookEndpointIdFormat_IsCorrect(string input)
+    {
+        Assert.Matches(Constants.WebhookEndpointIdFormat, input);
     }
 }

--- a/tests/FaluCli.Tests/ConstantsTests.cs
+++ b/tests/FaluCli.Tests/ConstantsTests.cs
@@ -9,4 +9,13 @@ public class ConstantsTests
     {
         Assert.Equal("128 KiB", Constants.MaxMpesaStatementFileSizeString);
     }
+
+    [Theory]
+    [InlineData("wksp_602cd2747409e867a240d000")]
+    [InlineData("tr_60ffe3f79c1deb8060f91312")]
+    [InlineData("mtmpl_27e868O6xW4NYrQb3WvxDb8iW6D")]
+    public void ObjectIdFormat_IsCorrect(string input)
+    {
+        Assert.Matches(Constants.ObjectIdFormat, input);
+    }
 }

--- a/tests/FaluCli.Tests/FaluCli.Tests.csproj
+++ b/tests/FaluCli.Tests/FaluCli.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FaluCli\FaluCli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FaluCli.Tests/FaluCli.Tests.csproj
+++ b/tests/FaluCli.Tests/FaluCli.Tests.csproj
@@ -1,4 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Falu.Tests</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FaluCli\FaluCli.csproj" />


### PR DESCRIPTION
Validate string inputs that must match certain formats. For example API keys and workspace identifiers.