### PR TITLE
Config commands

### DIFF
--- a/src/FaluCli/Commands/Config/ConfigClearAllCommand.cs
+++ b/src/FaluCli/Commands/Config/ConfigClearAllCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace Falu.Commands.Config;
+
+public class ConfigClearAllCommand : Command
+{
+    public ConfigClearAllCommand() : base("all", "Clear all cofiguration values by deleting the configuration file.")
+    {
+    }
+}
+
+public class ConfigClearAuthenticationCommand : Command
+{
+    public ConfigClearAuthenticationCommand() : base("authentication", "Clear cofiguration values related to authenticatin.")
+    {
+    }
+}

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -19,16 +19,41 @@ internal class ConfigCommandHandler : ICommandHandler
 
         switch (context.ParseResult.CommandResult.Command)
         {
+            case ConfigShowCommand:
+                {
+                    var values = await configValuesProvider.GetConfigValuesAsync(cancellationToken);
+                    var data = new Dictionary<string, object?>
+                    {
+                        ["ActiveWorkspaceId"] = values.ActiveWorkspaceId,
+                        ["ActiveLiveMode"] = values.ActiveLiveMode,
+                    };
+
+                    var str = data.RemoveDefaultAndEmpty().MakePaddedString("=");
+                    if (string.IsNullOrWhiteSpace(str))
+                    {
+                        logger.LogInformation("Configuration values are empty or only contain sensitive information.");
+                    }
+                    else
+                    {
+                        logger.LogInformation("Configuration values:\r\n{Values}", str);
+                    }
+
+                    break;
+                }
             case ConfigClearAuthenticationCommand:
-                logger.LogInformation("Removing authentication configuration ...");
-                await configValuesProvider.ClearAuthenticationAsync(cancellationToken);
-                logger.LogInformation("Successfully removed all authentication configuration values.");
-                break;
+                {
+                    logger.LogInformation("Removing authentication configuration ...");
+                    await configValuesProvider.ClearAuthenticationAsync(cancellationToken);
+                    logger.LogInformation("Successfully removed all authentication configuration values.");
+                    break;
+                }
             case ConfigClearAllCommand:
-                logger.LogInformation("Clearing all configuration values ...");
-                configValuesProvider.ClearAll();
-                logger.LogInformation("Successfully removed all configuration values and the configuration file.");
-                break;
+                {
+                    logger.LogInformation("Clearing all configuration values ...");
+                    configValuesProvider.ClearAll();
+                    logger.LogInformation("Successfully removed all configuration values and the configuration file.");
+                    break;
+                }
         }
 
         return 0;

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -40,6 +40,27 @@ internal class ConfigCommandHandler : ICommandHandler
 
                     break;
                 }
+            case ConfigSetCommand:
+                {
+                    var values = await configValuesProvider.GetConfigValuesAsync(cancellationToken);
+
+                    var key = context.ParseResult.ValueForArgument<string>("key")!.ToLower();
+                    var value = context.ParseResult.ValueForArgument<string>("value")!;
+                    switch (key)
+                    {
+                        case "workspace":
+                            values.DefaultWorkspaceId = value;
+                            break;
+                        case "livemode":
+                            values.DefaultLiveMode = bool.Parse(value);
+                            break;
+                        default:
+                            throw new NotSupportedException($"The key '{key}' is no supported yet.");
+                    }
+                    await configValuesProvider.SaveConfigValuesAsync(cancellationToken);
+                    logger.LogInformation("Successfully set configuration '{Key}={Value}'.", key, value);
+                    break;
+                }
             case ConfigClearAuthenticationCommand:
                 {
                     logger.LogInformation("Removing authentication configuration ...");

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -61,7 +61,7 @@ internal class ConfigCommandHandler : ICommandHandler
                     logger.LogInformation("Successfully set configuration '{Key}={Value}'.", key, value);
                     break;
                 }
-            case ConfigClearAuthenticationCommand:
+            case ConfigClearAuthCommand:
                 {
                     await configValuesProvider.ClearAuthenticationAsync(cancellationToken);
                     logger.LogInformation("Successfully removed all authentication configuration values.");

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -24,8 +24,8 @@ internal class ConfigCommandHandler : ICommandHandler
                     var values = await configValuesProvider.GetConfigValuesAsync(cancellationToken);
                     var data = new Dictionary<string, object?>
                     {
-                        ["ActiveWorkspaceId"] = values.ActiveWorkspaceId,
-                        ["ActiveLiveMode"] = values.ActiveLiveMode,
+                        ["DefaultWorkspaceId"] = values.DefaultWorkspaceId,
+                        ["DefaultLiveMode"] = values.DefaultLiveMode,
                     };
 
                     var str = data.RemoveDefaultAndEmpty().MakePaddedString("=");

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -63,14 +63,12 @@ internal class ConfigCommandHandler : ICommandHandler
                 }
             case ConfigClearAuthenticationCommand:
                 {
-                    logger.LogInformation("Removing authentication configuration ...");
                     await configValuesProvider.ClearAuthenticationAsync(cancellationToken);
                     logger.LogInformation("Successfully removed all authentication configuration values.");
                     break;
                 }
             case ConfigClearAllCommand:
                 {
-                    logger.LogInformation("Clearing all configuration values ...");
                     configValuesProvider.ClearAll();
                     logger.LogInformation("Successfully removed all configuration values and the configuration file.");
                     break;

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -1,0 +1,36 @@
+﻿using Falu.Config;
+
+namespace Falu.Commands.Config;
+
+internal class ConfigCommandHandler : ICommandHandler
+{
+    private readonly IConfigValuesProvider configValuesProvider;
+    private readonly ILogger logger;
+
+    public ConfigCommandHandler(IConfigValuesProvider configValuesProvider, ILogger<ConfigCommandHandler> logger)
+    {
+        this.configValuesProvider = configValuesProvider ?? throw new ArgumentNullException(nameof(configValuesProvider));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<int> InvokeAsync(InvocationContext context)
+    {
+        var cancellationToken = context.GetCancellationToken();
+
+        switch (context.ParseResult.CommandResult.Command)
+        {
+            case ConfigClearAuthenticationCommand:
+                logger.LogInformation("Removing authentication configuration ...");
+                await configValuesProvider.ClearAuthenticationAsync(cancellationToken);
+                logger.LogInformation("Successfully removed all authentication configuration values.");
+                break;
+            case ConfigClearAllCommand:
+                logger.LogInformation("Clearing all configuration values ...");
+                configValuesProvider.ClearAll();
+                logger.LogInformation("Successfully removed all configuration values and the configuration file.");
+                break;
+        }
+
+        return 0;
+    }
+}

--- a/src/FaluCli/Commands/Config/ConfigShowCommand.cs
+++ b/src/FaluCli/Commands/Config/ConfigShowCommand.cs
@@ -7,6 +7,18 @@ public class ConfigShowCommand : Command
     }
 }
 
+public class ConfigSetCommand : Command
+{
+    public ConfigSetCommand() : base("set", "Set a cofiguration value.")
+    {
+        this.AddArgument<string>(name: "key",
+                                 description: "The configuration key.",
+                                 configure: a => a.FromAmong("workspace", "livemode"));
+
+        this.AddArgument<string>(name: "value", description: "The configuration value.");
+    }
+}
+
 public class ConfigClearAllCommand : Command
 {
     public ConfigClearAllCommand() : base("all", "Clear all cofiguration values by deleting the configuration file.")

--- a/src/FaluCli/Commands/Config/ConfigShowCommand.cs
+++ b/src/FaluCli/Commands/Config/ConfigShowCommand.cs
@@ -26,9 +26,9 @@ public class ConfigClearAllCommand : Command
     }
 }
 
-public class ConfigClearAuthenticationCommand : Command
+public class ConfigClearAuthCommand : Command
 {
-    public ConfigClearAuthenticationCommand() : base("authentication", "Clear cofiguration values related to authenticatin.")
+    public ConfigClearAuthCommand() : base("auth", "Clear cofiguration values related to authentication.")
     {
     }
 }

--- a/src/FaluCli/Commands/Config/ConfigShowCommand.cs
+++ b/src/FaluCli/Commands/Config/ConfigShowCommand.cs
@@ -1,5 +1,12 @@
 ﻿namespace Falu.Commands.Config;
 
+public class ConfigShowCommand : Command
+{
+    public ConfigShowCommand() : base("show", "Show present cofiguration values.")
+    {
+    }
+}
+
 public class ConfigClearAllCommand : Command
 {
     public ConfigClearAllCommand() : base("all", "Clear all cofiguration values by deleting the configuration file.")

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -2,8 +2,8 @@
 
 internal record ConfigValues
 {
-    public string? ActiveWorkspaceId { get; set; }
-    public bool ActiveLiveMode { get; set; }
+    public string? DefaultWorkspaceId { get; set; }
+    public bool DefaultLiveMode { get; set; }
     public AuthenticationTokenConfigData? Authentication { get; set; }
 }
 

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -1,22 +1,10 @@
-﻿using IdentityModel.Client;
-
-namespace Falu.Config;
+﻿namespace Falu.Config;
 
 internal record ConfigValues
 {
     public string? ActiveWorkspaceId { get; set; }
     public bool ActiveLiveMode { get; set; }
     public AuthenticationTokenConfigData? Authentication { get; set; }
-
-    public void Update(TokenResponse response)
-    {
-        Authentication = new AuthenticationTokenConfigData
-        {
-            AccessToken = response.AccessToken,
-            RefreshToken = response.RefreshToken,
-            AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn).AddSeconds(-5),
-        };
-    }
 }
 
 internal record AuthenticationTokenConfigData

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -40,7 +40,12 @@ internal class ConfigValuesProvider : IConfigValuesProvider
     public async Task SaveConfigValuesAsync(TokenResponse response, CancellationToken cancellationToken = default)
     {
         values ??= await GetConfigValuesAsync(cancellationToken);
-        values.Update(response);
+        values.Authentication = new AuthenticationTokenConfigData
+        {
+            AccessToken = response.AccessToken,
+            RefreshToken = response.RefreshToken,
+            AccessTokenExpiry = DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn).AddSeconds(-5),
+        };
 
         await SaveConfigValuesAsync(cancellationToken);
     }

--- a/src/FaluCli/Config/ConfigValuesProvider.cs
+++ b/src/FaluCli/Config/ConfigValuesProvider.cs
@@ -44,4 +44,22 @@ internal class ConfigValuesProvider : IConfigValuesProvider
 
         await SaveConfigValuesAsync(cancellationToken);
     }
+
+    public async Task ClearAuthenticationAsync(CancellationToken cancellationToken = default)
+    {
+        values ??= await GetConfigValuesAsync(cancellationToken);
+        if (values.Authentication is not null)
+        {
+            values.Authentication = null;
+            await SaveConfigValuesAsync(cancellationToken);
+        }
+    }
+
+    public void ClearAll()
+    {
+        if (File.Exists(FilePath))
+        {
+            File.Delete(FilePath);
+        }
+    }
 }

--- a/src/FaluCli/Config/IConfigValuesProvider.cs
+++ b/src/FaluCli/Config/IConfigValuesProvider.cs
@@ -7,4 +7,7 @@ internal interface IConfigValuesProvider
     ValueTask<ConfigValues> GetConfigValuesAsync(CancellationToken cancellationToken = default);
     Task SaveConfigValuesAsync(CancellationToken cancellationToken = default);
     Task SaveConfigValuesAsync(TokenResponse response, CancellationToken cancellationToken = default);
+
+    Task ClearAuthenticationAsync(CancellationToken cancellationToken = default);
+    void ClearAll();
 }

--- a/src/FaluCli/Extensions/CollectionExtensions.cs
+++ b/src/FaluCli/Extensions/CollectionExtensions.cs
@@ -2,7 +2,7 @@
 
 internal static class CollectionExtensions
 {
-    public static string MakePaddedString(this IDictionary<string, object> dictionary, out int width, string separator = ": ")
+    public static string MakePaddedString(this IDictionary<string, object> dictionary, out int width, string separator = " : ")
     {
         if (dictionary is null) throw new ArgumentNullException(nameof(dictionary));
 
@@ -12,11 +12,11 @@ internal static class CollectionExtensions
             return string.Empty;
         }
 
-        var totalWidth = width = dictionary.Max(kvp => kvp.Key.Length) + 1;
+        var totalWidth = width = dictionary.Max(kvp => kvp.Key.Length);
         return string.Join("\r\n", dictionary.Select(kvp => $"{kvp.Key.PadRight(totalWidth)}{separator}{kvp.Value}"));
     }
 
-    public static string MakePaddedString(this IDictionary<string, object> dictionary, string separator = ": ")
+    public static string MakePaddedString(this IDictionary<string, object> dictionary, string separator = " : ")
     {
         return dictionary.MakePaddedString(out _, separator);
     }

--- a/src/FaluCli/Extensions/CollectionExtensions.cs
+++ b/src/FaluCli/Extensions/CollectionExtensions.cs
@@ -6,6 +6,12 @@ internal static class CollectionExtensions
     {
         if (dictionary is null) throw new ArgumentNullException(nameof(dictionary));
 
+        if (dictionary.Count == 0)
+        {
+            width = 0;
+            return string.Empty;
+        }
+
         var totalWidth = width = dictionary.Max(kvp => kvp.Key.Length) + 1;
         return string.Join("\r\n", dictionary.Select(kvp => $"{kvp.Key.PadRight(totalWidth)}{separator}{kvp.Value}"));
     }

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -50,7 +50,7 @@ var rootCommand = new RootCommand
         new ConfigSetCommand(),
         new Command("clear", "Clear configuration for the CLI.")
         {
-            new ConfigClearAuthenticationCommand(),
+            new ConfigClearAuthCommand(),
             new ConfigClearAllCommand(),
         },
     },
@@ -108,7 +108,7 @@ var builder = new CommandLineBuilder(rootCommand)
         host.UseCommandHandler<ConfigShowCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigSetCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigClearAllCommand, ConfigCommandHandler>();
-        host.UseCommandHandler<ConfigClearAuthenticationCommand, ConfigCommandHandler>();
+        host.UseCommandHandler<ConfigClearAuthCommand, ConfigCommandHandler>();
     })
     .UseFaluDefaults()
     .UseUpdateChecker() /* update checker middleware must be added last because it only prints what the checker has */;

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Falu;
+using Falu.Commands.Config;
 using Falu.Commands.Events;
 using Falu.Commands.Login;
 using Falu.Commands.Money;
@@ -41,6 +42,15 @@ var rootCommand = new RootCommand
     new Command("transfer-reversals", "Manage transfer reversals.")
     {
         new UploadMpesaStatementCommand(FaluObjectKind.TransferReversals),
+    },
+
+    new Command("config", "Manage configuration for the CLI.")
+    {
+        new Command("clear", "Clear configuration for the CLI.")
+        {
+            new ConfigClearAllCommand(),
+            new ConfigClearAuthenticationCommand(),
+        },
     },
 };
 
@@ -93,6 +103,8 @@ var builder = new CommandLineBuilder(rootCommand)
         host.UseCommandHandler<PullTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<PushTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<UploadMpesaStatementCommand, UploadMpesaStatementCommandHandler>();
+        host.UseCommandHandler<ConfigClearAllCommand, ConfigCommandHandler>();
+        host.UseCommandHandler<ConfigClearAuthenticationCommand, ConfigCommandHandler>();
     })
     .UseFaluDefaults()
     .UseUpdateChecker() /* update checker middleware must be added last because it only prints what the checker has */;

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -47,10 +47,11 @@ var rootCommand = new RootCommand
     new Command("config", "Manage configuration for the CLI.")
     {
         new ConfigShowCommand(),
+        new ConfigSetCommand(),
         new Command("clear", "Clear configuration for the CLI.")
         {
-            new ConfigClearAllCommand(),
             new ConfigClearAuthenticationCommand(),
+            new ConfigClearAllCommand(),
         },
     },
 };
@@ -105,6 +106,7 @@ var builder = new CommandLineBuilder(rootCommand)
         host.UseCommandHandler<PushTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<UploadMpesaStatementCommand, UploadMpesaStatementCommandHandler>();
         host.UseCommandHandler<ConfigShowCommand, ConfigCommandHandler>();
+        host.UseCommandHandler<ConfigSetCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigClearAllCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigClearAuthenticationCommand, ConfigCommandHandler>();
     })

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -46,6 +46,7 @@ var rootCommand = new RootCommand
 
     new Command("config", "Manage configuration for the CLI.")
     {
+        new ConfigShowCommand(),
         new Command("clear", "Clear configuration for the CLI.")
         {
             new ConfigClearAllCommand(),
@@ -103,6 +104,7 @@ var builder = new CommandLineBuilder(rootCommand)
         host.UseCommandHandler<PullTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<PushTemplatesCommand, TemplatesCommandHandler>();
         host.UseCommandHandler<UploadMpesaStatementCommand, UploadMpesaStatementCommandHandler>();
+        host.UseCommandHandler<ConfigShowCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigClearAllCommand, ConfigCommandHandler>();
         host.UseCommandHandler<ConfigClearAuthenticationCommand, ConfigCommandHandler>();
     })

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -128,7 +128,7 @@ namespace Falu.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Refreshing access token failed. Most likely the refresh token is no longer valid.
         ///You can clear authentication information using the command:
-        ///falu config clear authentication.
+        ///falu config clear auth.
         /// </summary>
         internal static string RefreshingAccessTokenFailed {
             get {

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -145,7 +145,7 @@ Consult your Falu dashboard to confirm the permissions of the API key or ask you
   <data name="RefreshingAccessTokenFailed" xml:space="preserve">
     <value>Refreshing access token failed. Most likely the refresh token is no longer valid.
 You can clear authentication information using the command:
-falu config clear authentication</value>
+falu config clear auth</value>
   </data>
   <data name="RequestFailedHeader" xml:space="preserve">
     <value>Request to Falu servers failed.</value>


### PR DESCRIPTION
This PR adds commands and sub-commands for handling the config:

- `falu config show`
- `falu config set <workspace|livemode> <value>`
- `falu config clear auth`
- `falu config clear all`