### PR TITLE
Fixes for 2022 April 27

### DIFF
--- a/src/FaluCli/Commands/Login/LoginCommand.cs
+++ b/src/FaluCli/Commands/Login/LoginCommand.cs
@@ -4,6 +4,10 @@ internal class LoginCommand : Command
 {
     public LoginCommand() : base("login", "Login to your Falu account to setup the CLI")
     {
+        this.AddOption(new[] { "--no-browser", },
+                       description: "Set true to not open the browser automatically for authentication.",
+                       defaultValue: false);
+
         //this.AddOption(new[] { "-i", "--interactive", },
         //               description: "Run interactive configuration mode if you cannot open a browser.",
         //               defaultValue: false);

--- a/src/FaluCli/Commands/Login/LoginCommandHandler.cs
+++ b/src/FaluCli/Commands/Login/LoginCommandHandler.cs
@@ -54,11 +54,10 @@ internal class LoginCommandHandler : ICommandHandler
         var response = await client.RequestDeviceAuthorizationAsync(request, cancellationToken);
         if (response.IsError) throw new LoginException(response);
 
-        // This information is logged per line to make independent entries because logging is compressed by default
-        logger.LogInformation("Complete authentication in the browser.");
-        logger.LogInformation("User code   : {UserCode}", response.UserCode);
-        logger.LogInformation("Device code : {DeviceCode}", response.DeviceCode);
-        logger.LogInformation("Opening your browser at {response.VerificationUri}", response.VerificationUri);
+        // inform the user where to authentication
+        logger.LogInformation("To authenticate, open your web browser at {VerificationUri} and enter the code {UserCode}.",
+                              response.VerificationUri,
+                              response.UserCode);
 
         // delay for 2 seconds before opening the browser for the user to see the code
         await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);

--- a/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluCli/Extensions/IServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 internal static class IServiceCollectionExtensions
 {
+    // services are registered as transit to allow for easier debugging because no scope is created by the parser
+
     public static IServiceCollection AddFaluClientForCli(this IServiceCollection services)
     {
         // A dummy ApiKey is used so that the options validator can pass
@@ -22,8 +24,8 @@ internal static class IServiceCollectionExtensions
                     client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("falucli", VersioningHelper.ProductVersion));
                 });
 
-        services.AddScoped<FaluCliClientHandler>();
-        services.AddScoped<HttpAuthenticationHandler>();
+        services.AddTransient<FaluCliClientHandler>();
+        services.AddTransient<HttpAuthenticationHandler>();
 
         return services;
     }
@@ -35,14 +37,14 @@ internal static class IServiceCollectionExtensions
 
     public static IServiceCollection AddConfigValuesProvider(this IServiceCollection services)
     {
-        return services.AddScoped<IConfigValuesProvider, ConfigValuesProvider>();
+        return services.AddTransient<IConfigValuesProvider, ConfigValuesProvider>();
     }
 
     public static IServiceCollection AddOpenIdServices(this IServiceCollection services)
     {
         services.AddHttpClient(Constants.OpenIdCategoryOrClientName);
 
-        services.AddScoped<IDiscoveryCache>(p =>
+        services.AddTransient<IDiscoveryCache>(p =>
         {
             var httpClientFactory = p.GetRequiredService<IHttpClientFactory>();
             var client = httpClientFactory.CreateOpenIdClient();


### PR DESCRIPTION
- Make automatically opening the browser on login optional
- Simplify log message for login in the browser
- Register services as transient instead of scoped because no scope is created by the parser