### PR TITLE
Reduce global options

### DIFF
--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Falu;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Res = Falu.Properties.Resources;
 
 namespace System.CommandLine;
@@ -239,17 +238,6 @@ public static class CommandExtensions
 
     public static Command AddCommonGlobalOptions(this Command command)
     {
-        command.AddGlobalOption(aliases: new[] { "--apikey", },
-                                description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...",
-                                format: Constants.ApiKeyFormat);
-
-        command.AddGlobalOption(aliases: new[] { "--workspace", },
-                                description: "The identifier of the workspace being accessed. Required when login is by user account. Example: wksp_610010be9228355f14ce6e08",
-                                format: Constants.WorkspaceIdFormat);
-
-        command.AddGlobalOption<bool>(aliases: new[] { "--live", },
-                                      description: "Whether the entity resides in live mode or not. Required when login is by user account.");
-
         command.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);
 
         return command;

--- a/src/FaluCli/Extensions/CommandExtensions.cs
+++ b/src/FaluCli/Extensions/CommandExtensions.cs
@@ -235,11 +235,4 @@ public static class CommandExtensions
     }
 
     #endregion
-
-    public static Command AddCommonGlobalOptions(this Command command)
-    {
-        command.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);
-
-        return command;
-    }
 }

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -57,7 +57,7 @@ var rootCommand = new RootCommand
 };
 
 rootCommand.Description = "Official CLI tool for Falu.";
-rootCommand.AddCommonGlobalOptions();
+rootCommand.AddGlobalOption(new[] { "-v", "--verbose" }, "Whether to output verbosely.", false);
 
 var builder = new CommandLineBuilder(rootCommand)
     .UseHost(_ => Host.CreateDefaultBuilder(args), host =>

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -13,33 +13,33 @@ var rootCommand = new RootCommand
     new LoginCommand(),
     new LogoutCommand(),
 
-    new Command("events", "Work with events on Falu.")
+    new WorkspacedCommand("events", "Work with events on Falu.")
     {
         new RetryCommand(),
     },
 
-    new Command("templates", "Manage message templates.")
+    new WorkspacedCommand("templates", "Manage message templates.")
     {
         new PullTemplatesCommand(),
         new PushTemplatesCommand(),
     },
 
-    new Command("payments", "Manage payments.")
+    new WorkspacedCommand("payments", "Manage payments.")
     {
         new UploadMpesaStatementCommand(FaluObjectKind.Payments),
     },
 
-    new Command("payment-refunds", "Manage payment refunds.")
+    new WorkspacedCommand("payment-refunds", "Manage payment refunds.")
     {
         new UploadMpesaStatementCommand(FaluObjectKind.PaymentRefunds),
     },
 
-    new Command("transfers", "Manage transfers.")
+    new WorkspacedCommand("transfers", "Manage transfers.")
     {
         new UploadMpesaStatementCommand(FaluObjectKind.Transfers),
     },
 
-    new Command("transfer-reversals", "Manage transfer reversals.")
+    new WorkspacedCommand("transfer-reversals", "Manage transfer reversals.")
     {
         new UploadMpesaStatementCommand(FaluObjectKind.TransferReversals),
     },

--- a/src/FaluCli/WorkspacedCommand.cs
+++ b/src/FaluCli/WorkspacedCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace Falu;
+
+public class WorkspacedCommand : Command
+{
+    public WorkspacedCommand(string name, string? description = null) : base(name, description)
+    {
+    }
+}

--- a/src/FaluCli/WorkspacedCommand.cs
+++ b/src/FaluCli/WorkspacedCommand.cs
@@ -4,5 +4,15 @@ public class WorkspacedCommand : Command
 {
     public WorkspacedCommand(string name, string? description = null) : base(name, description)
     {
+        this.AddGlobalOption(aliases: new[] { "--apikey", },
+                             description: "The API key to use for the command. Required it not logged in or when accessing another workspace. Looks like: sk_test_LdVyn0upN...",
+                             format: Constants.ApiKeyFormat);
+
+        this.AddGlobalOption(aliases: new[] { "--workspace", },
+                             description: "The identifier of the workspace being accessed. Required when login is by user account. Example: wksp_610010be9228355f14ce6e08",
+                             format: Constants.WorkspaceIdFormat);
+
+        this.AddGlobalOption<bool>(aliases: new[] { "--live", },
+                                   description: "Whether the entity resides in live mode or not. Required when login is by user account.");
     }
 }


### PR DESCRIPTION
Remove global options for workspace, api key, and live mode from commands that do not operate in an workspace context.