### PR TITLE
Allow specifying of idempotency key using the `--idempotency-key` option.

### DIFF
--- a/src/FaluCli/Client/FaluCliClientHandler.cs
+++ b/src/FaluCli/Client/FaluCliClientHandler.cs
@@ -13,11 +13,18 @@ internal class FaluCliClientHandler : DelegatingHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var workspaceId = context.ParseResult.ValueForOption<string>("--workspace");
+        var idempotencyKey = context.ParseResult.ValueForOption<string>("--idempotency-key");
         var live = context.ParseResult.ValueForOption<bool?>("--live");
 
         if (!string.IsNullOrWhiteSpace(workspaceId))
         {
             request.Headers.Add("X-Workspace-Id", workspaceId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            request.Headers.Remove("X-Idempotency-Key"); // avoid multiple values or headers
+            request.Headers.Add("X-Idempotency-Key", idempotencyKey);
         }
 
         if (live is not null)

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -24,6 +24,7 @@ internal class Constants
     public static readonly string MaxMpesaStatementFileSizeString = MaxMpesaStatementFileSize.ToBinaryString();
 
     public static readonly Regex WorkspaceIdFormat = new(@"^wksp_[a-zA-Z0-9]{20,30}$");
+    public static readonly Regex IdempotencyKeyFormat = new (@"^[a-zA-Z0-9-_]{2,128}$");
     public static readonly Regex ApiKeyFormat = new(@"^^[s|p]k_(?:live|test)_[0-9a-zA-Z]{20,30}$");
     public static readonly Regex EventIdFormat = new(@"^evt_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex WebhookEndpointIdFormat = new(@"^we_[a-zA-Z0-9]{20,30}$");

--- a/src/FaluCli/WorkspacedCommand.cs
+++ b/src/FaluCli/WorkspacedCommand.cs
@@ -15,5 +15,9 @@ public class WorkspacedCommand : Command
         // without this the nullable type, the option is not found because we have not migrated to the new bindings
         this.AddGlobalOption<bool?>(aliases: new[] { "--live", },
                                     description: "Whether the entity resides in live mode or not. Required when login is by user account.");
+
+        this.AddGlobalOption(aliases: new[] { "--idempotency-key", },
+                             description: "The identifier of the workspace being accessed. Required when login is by user account. Example: wksp_610010be9228355f14ce6e08",
+                             format: Constants.IdempotencyKeyFormat);
     }
 }


### PR DESCRIPTION
An idempotency key can be specified when making a request in a workspace using the `--idempotency-key` option. The value must be between 2 and 128  characters in length, allowing alphanumeric characters, hyphens, and underscores.