### PR TITLE
Handle empty lines in the CSV file for sending messages before splitting

### DIFF
--- a/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
@@ -24,7 +24,11 @@ public abstract class AsbtractSendMessagesCommand : Command
                                        return;
                                    }
 
-                                   var numbers = File.ReadAllText(value).Split(',', StringSplitOptions.RemoveEmptyEntries);
+                                   var numbers = File.ReadAllText(value)
+                                                     .Replace("\r\n", ",")
+                                                     .Replace("\r", ",")
+                                                     .Replace("\n", ",")
+                                                     .Split(',', StringSplitOptions.RemoveEmptyEntries);
                                    or.ErrorMessage = ValidateNumbers(or.Option.Name, numbers);
                                });
 

--- a/src/FaluCli/Commands/Messages/SendMessagesCommandHandler.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommandHandler.cs
@@ -35,7 +35,11 @@ internal class SendMessagesCommandHandler : ICommandHandler
         // read the numbers from the CSV file
         if (tos is null || tos.Length == 0)
         {
-            tos = File.ReadAllText(filePath!).Split(',', StringSplitOptions.RemoveEmptyEntries);
+            tos = File.ReadAllText(filePath!)
+                      .Replace("\r\n", ",")
+                      .Replace("\r", ",")
+                      .Replace("\n", ",")
+                      .Split(',', StringSplitOptions.RemoveEmptyEntries);
         }
 
         var stream = context.ParseResult.ValueForOption<string>("--stream")!;


### PR DESCRIPTION
Handle empty lines in the CSV file for sending messages before splitting.