### PR TITLE
Update and fixes for 2022-09-12 (Part 1)

### DIFF
--- a/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
@@ -40,8 +40,8 @@ public abstract class AsbtractSendMessagesCommand : Command
         this.AddOption<DateTimeOffset?>(new[] { "--schedule-time", "--time", },
                                         description: "The time at which the message(s) should be in the future.");
 
-        this.AddOption<TimeSpan?>(new[] { "--schedule-delay", "--delay", },
-                                  description: "The delay to be applied by the server before sending the message(s).");
+        this.AddOption<string>(new[] { "--schedule-delay", "--delay", },
+                               description: "The delay to be applied by the server before sending the message(s).");
     }
 
     private static string? ValidateNumbers(string optionName, string[] numbers)

--- a/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
@@ -40,8 +40,9 @@ public abstract class AsbtractSendMessagesCommand : Command
         this.AddOption<DateTimeOffset?>(new[] { "--schedule-time", "--time", },
                                         description: "The time at which the message(s) should be in the future.");
 
-        this.AddOption<string>(new[] { "--schedule-delay", "--delay", },
-                               description: "The delay to be applied by the server before sending the message(s).");
+        this.AddOption(new[] { "--schedule-delay", "--delay", },
+                       description: "The delay (in ISO8601 duration format) to be applied by the server before sending the message(s).",
+                       format: Constants.Iso8061DurationFormat);
     }
 
     private static string? ValidateNumbers(string optionName, string[] numbers)

--- a/src/FaluCli/Commands/Messages/SendMessagesCommandHandler.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommandHandler.cs
@@ -133,9 +133,7 @@ internal class SendMessagesCommandHandler : ICommandHandler
             rr.EnsureSuccess();
 
             var response = rr.Resource!;
-            // TODO: update this to use the schedule
-            logger.LogInformation("Scheduled {MessageId} for sending at {Scheduled:r}.", response.Ids![0], /*response.Schedule?.Time ??*/ response.Created);
-
+            logger.LogInformation("Scheduled {MessageId} for sending at {Scheduled:r}.", response.Id, response.Schedule?.Time ?? response.Created);
         }
         else
         {
@@ -150,7 +148,7 @@ internal class SendMessagesCommandHandler : ICommandHandler
 
             var response = rr.Resource!;
             var ids = response.Messages!;
-            logger.LogInformation("Scheduled {Count} for sending at {Scheduled:r}.", ids.Count, response.Schedule?.Time ?? response.Created);
+            logger.LogInformation("Scheduled {Count} messages for sending at {Scheduled:r}.", ids.Count, response.Schedule?.Time ?? response.Created);
             logger.LogDebug("Message Id(s):\r\n-{Ids}", string.Join("\r\n-", ids));
         }
     }

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -31,4 +31,5 @@ internal class Constants
     public static readonly Regex MessageTemplateIdFormat = new(@"^(?:mtpl|tmpl)_[a-zA-Z0-9]{20,30}$");
     public static readonly Regex MessageTemplateAliasFormat = new(@"^[a-zA-Z]([a-zA-Z0-9\-_]+)$");
     public static readonly Regex E164PhoneNumberFormat = new(@"^\+[1-9]\d{1,14}$"); // https://ihateregex.io/expr/e164-phone/
+    public static readonly Regex Iso8061DurationFormat = new(@"^P(([0-9.,]+Y)?([0-9.,]+M)?([0-9.,]+W)?([0-9.,]+D)?)(T([0-9.,]+H)?([0-9.,]+M)?([0-9.,]+S)?)?$"); // https://gist.github.com/tristanls/356ce5aea0054b770d49
 }

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="Falu" Version="1.7.1" />
+    <PackageReference Include="Falu" Version="1.7.2" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Octokit" Version="2.0.1" />

--- a/tests/FaluCli.Tests/ConstantsTests.cs
+++ b/tests/FaluCli.Tests/ConstantsTests.cs
@@ -82,4 +82,15 @@ public class ConstantsTests
     {
         Assert.Matches(Constants.E164PhoneNumberFormat, input);
     }
+
+    [Theory]
+    [InlineData("P2W")]
+    [InlineData("PT21M")]
+    [InlineData("P3Y6M4DT12H30M5S")]
+    [InlineData("P3,2Y6.5M4,7DT")]
+    [InlineData("PT57H30.5M3,77262S")]
+    public void Iso8061DurationFormat_IsCorrect(string input)
+    {
+        Assert.Matches(Constants.Iso8061DurationFormat, input);
+    }
 }


### PR DESCRIPTION
- Bump Falu from 1.7.1 to 1.7.2 hence update logs for sending messages.
- Added regex for ISO8601 duration hence update the `--schedule-delay` option type and validation.