### PR TITLE
Fixes on 2022-May-26

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,20 +2,7 @@
   <!-- There is nothing else to import. -->
 
   <PropertyGroup>
-    <!--
-      Using net7.0 causes errors since we publish with trimming:
-      - Constructors for command handlers cannot be found.
-      - Deserialization of JsonWebKeySet (required for login) does not work
-
-      We wait until there is a new version of some of these libraries.
-      Since .net6 is LTS and we generate framework independent code, we are safe for now.
-      PublishAot=true will not solve the problem because it also uses trimming.
-
-      Updating to more recent patterns of using the System.CommandLine libraries such as binding
-      may solve some of the issues. Maybe consider moving entirely to the more stable Spectre.Cli
-      if System.CommandLin doesn't GA within reasonable time.
-    -->
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
+++ b/src/FaluCli/Commands/Messages/SendMessagesCommand.cs
@@ -55,7 +55,7 @@ public abstract class AsbtractSendMessagesCommand : Command
     private static string? ValidateNumbers(string optionName, string[] numbers)
     {
         // ensure not more than 500*1000 (500 per batch and 1000 batches per request)
-        var limit = 500_000;
+        var limit = 500_000; // TODO: limit is 1k
         if (numbers.Length > limit)
         {
             return string.Format(Res.TooManyMessagesToBeSent, limit);

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -121,13 +121,8 @@ var builder = new CommandLineBuilder(rootCommand)
             services.AddTransient<LogoutCommandHandler>();
             services.AddTransient<RetryCommandHandler>();
             services.AddTransient<SendMessagesCommandHandler>();
-            services.AddTransient<SendMessagesCommandHandler>();
-            services.AddTransient<TemplatesCommandHandler>();
             services.AddTransient<TemplatesCommandHandler>();
             services.AddTransient<UploadMpesaStatementCommandHandler>();
-            services.AddTransient<ConfigCommandHandler>();
-            services.AddTransient<ConfigCommandHandler>();
-            services.AddTransient<ConfigCommandHandler>();
             services.AddTransient<ConfigCommandHandler>();
         });
 


### PR DESCRIPTION
- Migrate back to .net7 given that the trimming issues are sorted
- Remove duplicate registrations of command handlers
- Added TODO on messages limit