### PR TITLE
Trimming fixes

### DIFF
--- a/src/FaluCli/Extensions/IHostBuilderExtensions.cs
+++ b/src/FaluCli/Extensions/IHostBuilderExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.CommandLine.Hosting;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.Hosting;
+
+internal static class IHostBuilderExtensions
+{
+    // this exists to work around trimming which does not keep constructors by default in the System.CommandLine.Hosting library
+    // though Microsoft.Extensions.DependencyInjection does
+    public static IHostBuilder UseCommandHandlerTrimmable<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCommand,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler>(this IHostBuilder builder)
+        where TCommand : Command
+        where THandler : ICommandHandler
+    {
+        return builder.UseCommandHandler<TCommand, THandler>();
+    }
+}

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="Falu" Version="1.11.3" />
+    <PackageReference Include="Falu" Version="1.11.4" />
     <PackageReference Include="IdentityModel" Version="6.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Octokit" Version="6.0.0" />

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -110,37 +110,23 @@ var builder = new CommandLineBuilder(rootCommand)
             services.AddUpdateChecker();
             services.AddConfigValuesProvider();
             services.AddOpenIdServices();
-
-            /*
-             * These registrations/additions are necessary when trimming
-             * maybe until the next version of System.CommandLine
-             * 
-             * Alternatively consider migrating to Spectre
-             */
-            services.AddTransient<LoginCommandHandler>();
-            services.AddTransient<LogoutCommandHandler>();
-            services.AddTransient<RetryCommandHandler>();
-            services.AddTransient<SendMessagesCommandHandler>();
-            services.AddTransient<TemplatesCommandHandler>();
-            services.AddTransient<UploadMpesaStatementCommandHandler>();
-            services.AddTransient<ConfigCommandHandler>();
         });
 
         // System.CommandLine library does not create a scope, so we should skip validation of scopes
         host.UseDefaultServiceProvider(o => o.ValidateScopes = false);
 
-        host.UseCommandHandler<LoginCommand, LoginCommandHandler>();
-        host.UseCommandHandler<LogoutCommand, LogoutCommandHandler>();
-        host.UseCommandHandler<RetryCommand, RetryCommandHandler>();
-        host.UseCommandHandler<SendRawMessagesCommand, SendMessagesCommandHandler>();
-        host.UseCommandHandler<SendTemplatedMessagesCommand, SendMessagesCommandHandler>();
-        host.UseCommandHandler<PullTemplatesCommand, TemplatesCommandHandler>();
-        host.UseCommandHandler<PushTemplatesCommand, TemplatesCommandHandler>();
-        host.UseCommandHandler<UploadMpesaStatementCommand, UploadMpesaStatementCommandHandler>();
-        host.UseCommandHandler<ConfigShowCommand, ConfigCommandHandler>();
-        host.UseCommandHandler<ConfigSetCommand, ConfigCommandHandler>();
-        host.UseCommandHandler<ConfigClearAllCommand, ConfigCommandHandler>();
-        host.UseCommandHandler<ConfigClearAuthCommand, ConfigCommandHandler>();
+        host.UseCommandHandlerTrimmable<LoginCommand, LoginCommandHandler>();
+        host.UseCommandHandlerTrimmable<LogoutCommand, LogoutCommandHandler>();
+        host.UseCommandHandlerTrimmable<RetryCommand, RetryCommandHandler>();
+        host.UseCommandHandlerTrimmable<SendRawMessagesCommand, SendMessagesCommandHandler>();
+        host.UseCommandHandlerTrimmable<SendTemplatedMessagesCommand, SendMessagesCommandHandler>();
+        host.UseCommandHandlerTrimmable<PullTemplatesCommand, TemplatesCommandHandler>();
+        host.UseCommandHandlerTrimmable<PushTemplatesCommand, TemplatesCommandHandler>();
+        host.UseCommandHandlerTrimmable<UploadMpesaStatementCommand, UploadMpesaStatementCommandHandler>();
+        host.UseCommandHandlerTrimmable<ConfigShowCommand, ConfigCommandHandler>();
+        host.UseCommandHandlerTrimmable<ConfigSetCommand, ConfigCommandHandler>();
+        host.UseCommandHandlerTrimmable<ConfigClearAllCommand, ConfigCommandHandler>();
+        host.UseCommandHandlerTrimmable<ConfigClearAuthCommand, ConfigCommandHandler>();
     })
     .UseFaluDefaults()
     .UseUpdateChecker() /* update checker middleware must be added last because it only prints what the checker has */;


### PR DESCRIPTION
Added `UseCommandHandlerTrimmable<,>(...)` extension which resolves issues to do with trimming instead of registering command handlers.
Also updated Falu to 1.11.14 which fixes issue with trimming on `FaluClient` and by extension `FaluCliClient`.
